### PR TITLE
✨ feat: cloudfront + s3

### DIFF
--- a/terraform/v1/envs/mvp/main.tf
+++ b/terraform/v1/envs/mvp/main.tf
@@ -20,8 +20,6 @@ module "network" {
   availability_zone        = var.availability_zone
   gcp_cidr_block           = var.gcp_cidr_block
 
-  common_tags = local.common_tags
-  name_prefix = local.name_prefix
 }
 
 module "security" {
@@ -33,7 +31,25 @@ module "security" {
 
   ingress_rules = var.ingress_rules
   egress_rules  = var.egress_rules
+}
+
+module "storage" {
+  source      = "../../modules/storage"
+  bucket_name = var.domain_name
 
   common_tags = local.common_tags
   name_prefix = local.name_prefix
+}
+
+module "cdn" {
+  source                      = "../../modules/cdn"
+  bucket_name                 = var.domain_name
+  bucket_arn                  = module.storage.bucket_arn
+  bucket_regional_domain_name = module.storage.bucket_regional_domain_name
+  domain_name                 = var.domain_name
+  acm_certificate_arn         = var.acm_certificate_arn
+
+  common_tags = local.common_tags
+  name_prefix = local.name_prefix
+
 }

--- a/terraform/v1/envs/mvp/variables.tf
+++ b/terraform/v1/envs/mvp/variables.tf
@@ -94,3 +94,16 @@ variable "assignee_tag" {
   description = "Write down Assignee Tag"
   type        = string
 }
+
+#cdn
+variable "acm_certificate_arn" {
+  description = "The ARN of the ACM certificate to use for HTTPS"
+  type        = string
+}
+
+variable "domain_name" {
+  description = "The custom domain name (CNAME) to associate with the CloudFront distribution"
+  type        = string
+}
+
+#storage

--- a/terraform/v1/modules/cdn/locals.tf
+++ b/terraform/v1/modules/cdn/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  default_tags = merge(
+    var.common_tags,
+    {
+      Module = var.module_name
+    }
+  )
+}

--- a/terraform/v1/modules/cdn/main.tf
+++ b/terraform/v1/modules/cdn/main.tf
@@ -74,7 +74,7 @@ resource "aws_cloudfront_distribution" "frontend" {
   tags = merge(
     local.default_tags,
     {
-      Name = "${var.name_prefix}-${var.common_tags.Environment}-vpc"
+      Name = "${var.name_prefix}-${var.common_tags.Environment}-cloudfront"
     }
   )
 

--- a/terraform/v1/modules/cdn/main.tf
+++ b/terraform/v1/modules/cdn/main.tf
@@ -1,0 +1,82 @@
+# modules/cloudfront/main.tf
+resource "aws_cloudfront_origin_access_identity" "oai" {
+  comment = "OAI for ${var.domain_name}"
+}
+
+resource "aws_s3_bucket_policy" "frontend_policy" {
+  bucket = var.bucket_name
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          AWS = aws_cloudfront_origin_access_identity.oai.iam_arn
+        },
+        Action   = "s3:GetObject",
+        Resource = "${var.bucket_arn}/*"
+      }
+    ]
+  })
+}
+
+resource "aws_cloudfront_distribution" "frontend" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "CloudFront for ${var.domain_name}"
+  default_root_object = "index.html"
+
+  aliases = [var.domain_name]
+
+  origin {
+    domain_name = var.bucket_regional_domain_name
+    origin_id   = "s3-origin"
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.oai.cloudfront_access_identity_path
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "s3-origin"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  price_class = "PriceClass_100"
+
+  viewer_certificate {
+    acm_certificate_arn      = var.acm_certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tags = merge(
+    local.default_tags,
+    {
+      Name = "${var.name_prefix}-${var.common_tags.Environment}-vpc"
+    }
+  )
+
+}
+

--- a/terraform/v1/modules/cdn/ouputs.tf
+++ b/terraform/v1/modules/cdn/ouputs.tf
@@ -1,0 +1,9 @@
+output "cloudfront_domain_name" {
+  description = "The domain name of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.frontend.domain_name
+}
+
+output "cloudfront_zone_id" {
+  description = "The Route 53 hosted zone ID for the CloudFront distribution"
+  value       = aws_cloudfront_distribution.frontend.hosted_zone_id
+}

--- a/terraform/v1/modules/cdn/variables.tf
+++ b/terraform/v1/modules/cdn/variables.tf
@@ -1,0 +1,42 @@
+variable "bucket_name" {
+  description = "The name of the S3 bucket to serve as the CloudFront origin"
+  type        = string
+}
+
+variable "bucket_arn" {
+  description = "The ARN of the S3 bucket for policy statements"
+  type        = string
+}
+
+variable "bucket_regional_domain_name" {
+  description = "The regional domain name of the S3 bucket (e.g. bucket.s3.region.amazonaws.com)"
+  type        = string
+}
+
+variable "acm_certificate_arn" {
+  description = "The ARN of the ACM certificate to use for HTTPS"
+  type        = string
+}
+
+variable "domain_name" {
+  description = "The custom domain name (CNAME) to associate with the CloudFront distribution"
+  type        = string
+}
+
+
+#tag용 변수
+variable "module_name" {
+  description = "Module name used for Module tag"
+  type        = string
+  default     = "cdn"
+}
+
+variable "common_tags" {
+  description = "공통 태그"
+  type        = map(string)
+}
+
+variable "name_prefix" {
+  description = "Name tag's prefix"
+  type        = string
+}

--- a/terraform/v1/modules/storage/locals.tf
+++ b/terraform/v1/modules/storage/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  default_tags = merge(
+    var.common_tags,
+    {
+      Module = var.module_name
+    }
+  )
+}

--- a/terraform/v1/modules/storage/main.tf
+++ b/terraform/v1/modules/storage/main.tf
@@ -1,0 +1,38 @@
+
+resource "aws_s3_bucket_cors_configuration" "frontend_cors" {
+  bucket = var.bucket_name
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "POST", "PUT", "DELETE", "HEAD"]
+    allowed_origins = ["*"]
+    expose_headers  = []
+    max_age_seconds = 3000
+  }
+}
+
+resource "aws_s3_bucket" "frontend" {
+  bucket = var.bucket_name
+
+  tags = merge(
+    local.default_tags,
+    {
+      Name = "${var.name_prefix}-${var.common_tags.Environment}-frontend"
+    }
+  )
+
+}
+
+resource "aws_s3_bucket_website_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "index.html"
+  }
+}
+
+

--- a/terraform/v1/modules/storage/outputs.tf
+++ b/terraform/v1/modules/storage/outputs.tf
@@ -1,0 +1,15 @@
+// outputs.tf
+output "website_url" {
+  description = "The website endpoint of the S3 bucket"
+  value       = aws_s3_bucket_website_configuration.frontend.website_endpoint
+}
+
+output "bucket_arn" {
+  description = "The ARN of the S3 bucket"
+  value       = aws_s3_bucket.frontend.arn
+}
+
+output "bucket_regional_domain_name" {
+  description = "The regional domain name of the S3 bucket"
+  value       = aws_s3_bucket.frontend.bucket_regional_domain_name
+}

--- a/terraform/v1/modules/storage/variables.tf
+++ b/terraform/v1/modules/storage/variables.tf
@@ -1,0 +1,21 @@
+variable "bucket_name" {
+  description = "The name of the S3 bucket"
+  type        = string
+}
+
+#tag용 변수
+variable "module_name" {
+  description = "Module name used for Module tag"
+  type        = string
+  default     = "cdn"
+}
+
+variable "common_tags" {
+  description = "공통 태그"
+  type        = map(string)
+}
+
+variable "name_prefix" {
+  description = "Name tag's prefix"
+  type        = string
+}


### PR DESCRIPTION

### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #35 

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. cloudfront 모듈 추가
 - oai 설정
 - cloudfront_distribution 설정
2. cloudfront 용 storage(s3) 모듈 추가
 - s3 셀프 호스팅 설정 및 cors 설정 완료
 - 태깅 수정
3. env/mvp/main.tf에 cloudfront 및 storage 모듈 호출

### Screenshots or Video

<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->
<img width="586" alt="스크린샷 2025-05-01 오후 4 47 19" src="https://github.com/user-attachments/assets/590271c2-e78e-4eb0-8907-b2538d945ab8" />



### Testing

<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

1. terraform fmt 진행
2. terraform validate 진행
3. terraform plan 진행



### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

- route 53 연결 및 새로운 storage(백엔드 및 로깅 스토리지용) 추가 필요
- 클라우드 프론트 정책 확인 필요 (현재 정적 페이지 캐싱만을 고려했으므로, next.js ssl의 경우 캐싱 정책을 수정해야할 가능성 있음.) 
참고 링크: https://mercurial-muenster-c53.notion.site/1e6864ef286580dc90c6f473a9c79e89?pvs=4

